### PR TITLE
Fix RMagick deprication message

### DIFF
--- a/lib/compass-svg-polyfill/sass_functions.rb
+++ b/lib/compass-svg-polyfill/sass_functions.rb
@@ -1,7 +1,7 @@
 require 'tempfile'
 require 'fileutils'
 require 'digest'
-require 'RMagick' unless Object.const_defined?("Magick")
+require 'rmagick' unless Object.const_defined?("Magick")
 
 module Sass::Script::Functions
   def svg_polyfill(width, height, svgName, pngName, imageConverter)


### PR DESCRIPTION
Since the newer version of rmagick the following message is thrown: 
"[DEPRECATION] requiring "RMagick" is deprecated. Use "rmagick" instead"

This patch fixes this.
